### PR TITLE
Add Spanish, fix Portugese translation, and update readme

### DIFF
--- a/2048/2048/src/main/res/values-es/strings.xml
+++ b/2048/2048/src/main/res/values-es/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="high_score">PUNTUACIÓN ALTA</string>
+    <string name="continue_game">Cancelar</string>
+    <string name="endless">Modo \"Infinito\"</string>
+    <string name="for_now">Por ahora</string>
+    <string name="game_over">¡Juego Terminado!</string>
+    <string name="go_on">Pulsa Para Continuar</string>
+    <string name="app_name"></string>
+    <string name="reset">Reajustar</string>
+    <string name="reset_dialog_message">¿Seguro que quieres a reajustar el juego?</string>
+    <string name="reset_dialog_title">¿Reajutar el juego?</string>
+    <string name="score">PUNTAJE</string>
+    <string name="you_win">¡Te Ganas!</string>
+    <string name="instructions">Deslice para mover. 2 + 2 = 4. Alcanza 2048.</string>
+</resources>

--- a/2048/2048/src/main/res/values-pt-rPT/strings.xml
+++ b/2048/2048/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="high_score">RECORDE</string>
+    <string name="score">PONTUAÇÃO</string>
+    <string name="instructions">Deslize para mover. 2 + 2 = 4. Alcance 2048.</string>
+    <string name="you_win">Ganhou!</string>
+    <string name="game_over">Perdeu!</string>
+    <string name="go_on">Toque para Continuar</string>
+    <string name="for_now">Por agora…</string>
+    <string name="endless">Modo "Sem Fim"</string>
+
+    <!-- Confirmation dialog-->
+    <string name="reset">Reiniciar</string>
+    <string name="continue_game">Cancelar</string>
+    <string name="reset_dialog_title">Reiniciar o jogo?</string>
+    <string name="reset_dialog_message">Tem a certeza que quer reiniciar o jogo?</string>
+</resources>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 2048
 ====
 
-This is a port of Gabriele Cirulli's 2048 game to Android.
-
-All credit for game design goes to him.
+This is a port of Gabriele Cirulli's 2048 game to Android, all credit for game design goes to him.
 
 Logo redrawn by Margaret Lu.
 
-Original code: https://github.com/gabrielecirulli/2048
+[Original code](https://github.com/gabrielecirulli/2048) (github.com)
 
-Download from Google Play: https://play.google.com/store/apps/details?id=com.tpcstld.twozerogame
+[Download on Google Play](https://play.google.com/store/apps/details?id=com.tpcstld.twozerogame) (play.google.com)
 
 Use governed by the MIT License.
+
+## Contributing
+
+This is an open source project and PRs are welcome and appreciated. Here are some of the things that you could help out with: 
+
+* Add various language translations


### PR DESCRIPTION
* The portugal translation's name was `values-pt-PT`, while it should be `values-pt-rPT`
* The readme now has real markdown links instead of urls. I added some general information about contributing as well. It would be great if we could expand on this list.

Let me know if there is anything else that needs work!