### PR TITLE
Buffer new random tiles with direction information

### DIFF
--- a/2048/2048/src/main/java/com/tpcstld/twozerogame/MainGame.java
+++ b/2048/2048/src/main/java/com/tpcstld/twozerogame/MainGame.java
@@ -44,6 +44,7 @@ public class MainGame {
     public long highScore = 0;
     public long lastScore = 0;
     private long bufferScore = 0;
+    private Tile[] bufferTiles = new Tile[4];
 
     public MainGame(Context context, MainView view) {
         mContext = context;
@@ -76,19 +77,30 @@ public class MainGame {
     private void addStartTiles() {
         int startTiles = 2;
         for (int xx = 0; xx < startTiles; xx++) {
-            this.addRandomTile();
+            spawnTile(getRandomTile());
         }
     }
 
-    private void addRandomTile() {
+    private Tile getRandomTile() {
         if (grid.isCellsAvailable()) {
             int value = Math.random() < 0.9 ? 2 : 4;
             Tile tile = new Tile(grid.randomAvailableCell(), value);
-            spawnTile(tile);
+            return tile;
         }
+        return null;
+    }
+
+    private Tile getBufferedRandomTile(int direction) {
+        if (bufferTiles[direction] == null) {
+            bufferTiles[direction] = getRandomTile();
+        }
+        return bufferTiles[direction];
     }
 
     private void spawnTile(Tile tile) {
+        if (tile == null) {
+            return;
+        }
         grid.insertTile(tile);
         aGrid.startAnimation(tile.getX(), tile.getY(), SPAWN_ANIMATION,
                 SPAWN_ANIMATION_TIME, MOVE_ANIMATION_TIME, null); //Direction: -1 = EXPANDING
@@ -124,6 +136,9 @@ public class MainGame {
 
     private void saveUndoState() {
         grid.saveTiles();
+        if (canUndo) {
+            clearTileBuffer();
+        }
         canUndo = true;
         lastScore = bufferScore;
         lastGameState = bufferGameState;
@@ -144,6 +159,12 @@ public class MainGame {
             gameState = lastGameState;
             mView.refreshLastTime = true;
             mView.invalidate();
+        }
+    }
+
+    private void clearTileBuffer() {
+        for (int i = 0; i < bufferTiles.length; i++) {
+            bufferTiles[i] = null;
         }
     }
 
@@ -223,7 +244,7 @@ public class MainGame {
 
         if (moved) {
             saveUndoState();
-            addRandomTile();
+            spawnTile(getBufferedRandomTile(direction));
             checkLose();
         }
         mView.resyncTime();


### PR DESCRIPTION
First off, thanks for providing a FOSS, ad-free alternative of 2048. Much appreciated :+1: 

This PR mitigates an exploit where the player reverts the last move step to generate a new random tile for the chosen direction.
This may not happen. The undo function should only be available to correct accidental errors, not to improve the chances of success.